### PR TITLE
Fix/flexible grid layout

### DIFF
--- a/Assets/Prefabs/UI/CharacterBackground.prefab
+++ b/Assets/Prefabs/UI/CharacterBackground.prefab
@@ -166,7 +166,7 @@ MonoBehaviour:
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
@@ -259,7 +259,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 775, y: 80}
+  m_SizeDelta: {x: 775, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7222817613363345462
 CanvasRenderer:
@@ -543,7 +543,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 250}
+  m_SizeDelta: {x: 218.6858, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5639719723858738884
 CanvasRenderer:
@@ -895,7 +895,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 775, y: 80}
+  m_SizeDelta: {x: 775, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &3251771456488144165
 CanvasRenderer:

--- a/Assets/Scripts/UI/FlexibleGridLayout.cs
+++ b/Assets/Scripts/UI/FlexibleGridLayout.cs
@@ -78,10 +78,9 @@ public class FlexibleGridLayout : LayoutGroup
 
     public override void CalculateLayoutInputHorizontal()
     {
-        base.CalculateLayoutInputHorizontal();
-
         CalculateLayoutInputVertical();
     }
+    
     public override void SetLayoutHorizontal()
     {
 

--- a/Assets/Scripts/UI/FlexibleGridLayout.cs
+++ b/Assets/Scripts/UI/FlexibleGridLayout.cs
@@ -76,6 +76,12 @@ public class FlexibleGridLayout : LayoutGroup
         }
     }
 
+    public override void CalculateLayoutInputHorizontal()
+    {
+        base.CalculateLayoutInputHorizontal();
+
+        CalculateLayoutInputVertical();
+    }
     public override void SetLayoutHorizontal()
     {
 

--- a/Assets/Scripts/UI/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenuController.cs
@@ -116,8 +116,10 @@ public class MainMenuController : MonoBehaviour
         //Update all panels color
         for (int i = 0; i < playerBackgrounds.Count; i++)
         {
+            // Access the player identity
+            PlayerIdentity pi = playerInputs[i].GetComponent<PlayerIdentity>();
             // Update the visual loadout controller
-            playerBackgrounds[i].GetComponent<CharacterMenuLoadout>().SetupPreview("Player " + (i+1),playerInputs[i].GetComponent<PlayerIdentity>().color);
+            playerBackgrounds[i].GetComponent<CharacterMenuLoadout>().SetupPreview(pi.playerName, pi.color);
         }
     }
 

--- a/Assets/Scripts/UI/MainMenuController.cs
+++ b/Assets/Scripts/UI/MainMenuController.cs
@@ -117,9 +117,9 @@ public class MainMenuController : MonoBehaviour
         for (int i = 0; i < playerBackgrounds.Count; i++)
         {
             // Access the player identity
-            PlayerIdentity pi = playerInputs[i].GetComponent<PlayerIdentity>();
+            PlayerIdentity playerIdentity = playerInputs[i].GetComponent<PlayerIdentity>();
             // Update the visual loadout controller
-            playerBackgrounds[i].GetComponent<CharacterMenuLoadout>().SetupPreview(pi.playerName, pi.color);
+            playerBackgrounds[i].GetComponent<CharacterMenuLoadout>().SetupPreview(playerIdentity.playerName, playerIdentity.color);
         }
     }
 


### PR DESCRIPTION
Adresses an automatic centering issue that the flexible grid layout componenet has been struggling with.

- All layout element calculations are done in 'CalculateLayoutInputVertical()' A call has been added which performs the calculation when  'CalculateLayoutInputHorizontal()' is called.
- adds some minor polish to the character selection screen by reducing the character size to allow for a larger variety of aspect ratios.
- Player names are now accessed through the player identity script rather than deduced through indexing.
