### PR TITLE
Round ends quickly if in "testing mode"

### DIFF
--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -81,6 +81,12 @@ public class MatchController : MonoBehaviour
 
         playerFactory = FindObjectOfType<PlayerFactory>();
 
+        // Makes shooting end quickly if testing with 1 player
+        #if UNITY_EDITOR
+        if (PlayerInputManagerController.Singleton.playerInputs.Count == 1)
+            roundLength = 5f;
+        #endif
+
         StartNextRound();
 
 


### PR DESCRIPTION
Testing mode entails joining a match alone with the unity editor instead of a built version of the game.

If this is the case, the shooting round will end in 5 seconds.