### PR TITLE
Fix duplicate gun spawning on InitializeGun

### DIFF
--- a/Assets/Scripts/Augment/GunFactory.cs
+++ b/Assets/Scripts/Augment/GunFactory.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
 
 [RequireComponent(typeof(GunController))]
 public class GunFactory : MonoBehaviour
@@ -12,6 +13,9 @@ public class GunFactory : MonoBehaviour
         controller.bodyPrefab = bodyPrefab;
         controller.barrelPrefab = barrelPrefab;
         controller.extensionPrefab = extensionPrefab;
+
+        // Initialize everything
+        gun.GetComponent<GunFactory>().InitializeGun();
 
         return gun;
     }
@@ -36,10 +40,15 @@ public class GunFactory : MonoBehaviour
 
     private GunController gunController;
 
+#if UNITY_EDITOR
     private void Start()
     {
-        InitializeGun();
+        if (SceneManager.GetActiveScene().name == "GunTest")
+        {
+            InitializeGun();
+        }
     }
+#endif
 
     // Builds the gun from parts
     public void InitializeGun()

--- a/Assets/Scripts/Gamestate/MatchController.cs
+++ b/Assets/Scripts/Gamestate/MatchController.cs
@@ -82,10 +82,10 @@ public class MatchController : MonoBehaviour
         playerFactory = FindObjectOfType<PlayerFactory>();
 
         // Makes shooting end quickly if testing with 1 player
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         if (PlayerInputManagerController.Singleton.playerInputs.Count == 1)
             roundLength = 5f;
-        #endif
+#endif
 
         StartNextRound();
 
@@ -184,12 +184,12 @@ public class MatchController : MonoBehaviour
         var lastWinner = rounds.Last().Winner;
         if (lastWinner == null) { return false; }
         var wins = rounds.Where(round => round.IsWinner(lastWinner)).Count();
-        Debug.Log("Current winner (" + lastWinner.ToString() + ") has " + wins + " wins.");
+        Debug.Log($"Current winner ({lastWinner}) has {wins} wins.");
         if (wins >= 3)
         {
             // We have a winner!
             // TODO Go to victory scene
-            Debug.Log("Aaaaand the winner iiiiiiiis " + lastWinner.ToString());
+            Debug.Log($"Aaaaand the winner iiiiiiiis {lastWinner}");
 
             // Update playerInputs in preperation for Menu scene
             ChangeInputMappings("Menu");

--- a/Assets/Scripts/Gamestate/PlayerIdentity.cs
+++ b/Assets/Scripts/Gamestate/PlayerIdentity.cs
@@ -89,4 +89,9 @@ public class PlayerIdentity : MonoBehaviour
         }
         onInventoryChange?.Invoke(item);
     }
+
+    public override string ToString()
+    {
+        return name;
+    }
 }


### PR DESCRIPTION
GunFactory is a MonoBehaviour and is thus spawned in when one of its
static methods is called. In its Start method, it calls InitializeGun
to instantiate the gun it is supposed to build. This is *only* useful
in the GunTest scene, where we want a gun to show up automatically,
based on what the factory starts with. When we use InstantiateGun to
create a gun from other scenes, the Start method is also triggered and
creates a superfluous copy of the gun.

With this commit, the issue is avoided by initializing in InstantiateGun
and in Start *only when the scene in GunTest*.

Fixes #91 