### PR TITLE
Add GitHub Actions workflows for adding items to project board

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dev"
+    commit-message:
+      prefix: "👷"
+      include: "scope"

--- a/.github/workflows/_reusable_add-content-to-project.yml
+++ b/.github/workflows/_reusable_add-content-to-project.yml
@@ -1,0 +1,161 @@
+# This is a reusable workflow; see https://docs.github.com/en/actions/using-workflows/reusing-workflows.
+# It was created because GitHub projects' workflows (see e.g. https://github.com/orgs/hackerspace-ntnu/projects/1/workflows)
+# don't (currently) support doing the specific things done in the steps below.
+#
+# The workflow requires that the following repository variables have been created:
+# - `ORGANIZATION_PROJECT_NUMBER` - The number/ID in the project URL (https://github.com/orgs/hackerspace-ntnu/projects/1)
+# - `ORGANIZATION_PROJECT__STATUS_VALUE_FOR_CLOSED_ITEMS` - The value of the 'Status' field set for an item when closed
+#                                                           (see https://github.com/orgs/hackerspace-ntnu/projects/1/workflows/3836538)
+# and the following organization variables:
+# - `ORGANIZATION_NAME` - The name of the organization in the project URL (https://github.com/orgs/hackerspace-ntnu/projects/1)
+#
+# The workflow also expects that the following project workflows are turned on for the project:
+# - "Item closed" (https://github.com/orgs/hackerspace-ntnu/projects/1/workflows/3836538):
+#   - "When an item is closed": "issue, pull request"
+#   - "Set value": "Status: <the value of the `ORGANIZATION_PROJECT__STATUS_VALUE_FOR_CLOSED_ITEMS` repository variable>"
+# and that the following project workflows are turned off:
+# - "Item added to project"
+# - "Item reopened"
+# (The "Pull request merged" project workflow (https://github.com/orgs/hackerspace-ntnu/projects/1/workflows/3836539)
+# does not affect and is not affected by any of this.
+# However, it could be natural that it sets the same value as the "Item closed" project workflow.)
+
+name: Add content to project
+
+on:
+  workflow_call:
+    inputs:
+      content_id:
+        description: "The ID of an issue or a PR, to be added to this repo's GitHub project"
+        required: true
+        type: string
+      status_field_value_name:
+        description: "The name of one of the values of the project's (single select) 'Status' field, to set for the added project item"
+        required: true
+        type: string
+
+jobs:
+  add_content:
+    runs-on: ubuntu-latest
+    # Code based on https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions#example-workflow-authenticating-with-a-github-app
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.HACKERSPACE_BOT_APP_ID }}
+          private_key: ${{ secrets.HACKERSPACE_BOT_APP_PEM }}
+
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          ORGANIZATION: ${{ vars.ORGANIZATION_NAME }}
+          PROJECT_NUMBER: ${{ vars.ORGANIZATION_PROJECT_NUMBER }}
+          # This name is hardcoded by GitHub and cannot be changed
+          STATUS_FIELD_NAME: Status
+          STATUS_FIELD_VALUE_NAME: ${{ inputs.status_field_value_name }}
+        run: |
+          gh api graphql -f query='
+            query ($org: String!, $number: Int!) {
+              organization(login: $org) {
+                projectV2(number: $number) {
+                  id
+                  fields(first: 20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org="$ORGANIZATION" -F number="$PROJECT_NUMBER" > project_data.json
+
+          {
+            # The ID of this repo's GitHub project
+            echo "PROJECT_ID=$(jq -r '.data.organization.projectV2.id' project_data.json)"
+            # The ID of the project's status field
+            echo "STATUS_FIELD_ID=$(jq --arg FIELD_NAME "$STATUS_FIELD_NAME" -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD_NAME) | .id' project_data.json)"
+            # The ID of one of the values of the project's (single select) status field, with name `inputs.status_field_value_name`
+            echo "STATUS_FIELD_VALUE_ID=$(jq --arg FIELD_NAME "$STATUS_FIELD_NAME" --arg STATUS_NAME "$STATUS_FIELD_VALUE_NAME" -r '.data.organization.projectV2.fields.nodes[] | select(.name==$FIELD_NAME) | .options[] | select(.name==$STATUS_NAME) | .id' project_data.json)"
+          } >> "$GITHUB_ENV"
+
+      - name: Add content to project
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          CONTENT_ID: ${{ inputs.content_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation ($project: ID!, $content: ID!) {
+              addProjectV2ItemById(input: {projectId: $project, contentId: $content}) {
+                item {
+                  id
+                }
+              }
+            }' -f project="$PROJECT_ID" -f content="$CONTENT_ID" --jq '.data.addProjectV2ItemById.item.id' )"
+
+          # The ID of the project item (representing an issue or a PR with ID `inputs.content_id`), which was either added or already existed
+          echo "ITEM_ID=$item_id" >> "$GITHUB_ENV"
+
+      - name: Get project item data
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          gh api graphql -f query='
+            query ($itemId: ID!) {
+              node(id: $itemId) {
+                ... on ProjectV2Item {
+                  fieldValues(first: 20) {
+                    nodes {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                        field {
+                          ... on ProjectV2SingleSelectField {
+                            id
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f itemId="$ITEM_ID" > project_item_data.json
+
+          {
+            # The value of the project item's status field (with ID `env.STATUS_FIELD_ID`)
+            echo "STATUS_FIELD_VALUE=$(jq --arg FIELD_ID "$STATUS_FIELD_ID" -r '.data.node.fieldValues.nodes[] | select(.field.id==$FIELD_ID) | .name' project_item_data.json)"
+          } >> "$GITHUB_ENV"
+
+      - name: Set status
+        # Only set the status if it's not already set,
+        # or if it's a reopened issue/PR (as they should be marked with the value of `ORGANIZATION_PROJECT__STATUS_VALUE_FOR_CLOSED_ITEMS` when closed
+        # - see https://github.com/orgs/hackerspace-ntnu/projects/1/workflows/3836538)
+        if: ${{ !env.STATUS_FIELD_VALUE
+          || github.event.action == 'reopened' && env.STATUS_FIELD_VALUE == vars.ORGANIZATION_PROJECT__STATUS_VALUE_FOR_CLOSED_ITEMS }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          gh api graphql -f query='
+            mutation ($project: ID!, $item: ID!, $status_field: ID!, $status_value: String!) {
+              set_status: updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $status_field
+                value: {
+                  singleSelectOptionId: $status_value
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }' -f project="$PROJECT_ID" -f item="$ITEM_ID" -f status_field="$STATUS_FIELD_ID" -f status_value="$STATUS_FIELD_VALUE_ID" --silent

--- a/.github/workflows/label-release-pull-request.yml
+++ b/.github/workflows/label-release-pull-request.yml
@@ -1,0 +1,94 @@
+# This workflow makes a naive attempt at enforcing a convention that
+# PRs should generally always and only be labeled with the release label if it merges the development branch into the production branch.
+#
+# The workflow requires that the following repository variables have been created:
+# - `REPOSITORY_NAME` - The name of the repository
+# - `PRODUCTION_BRANCH_NAME` - The name of the repository's production branch (e.g. `main`)
+# - `DEVELOPMENT_BRANCH_NAME` - The name of the repository's development branch (e.g. `dev`)
+# - `RELEASE_LABEL_NAME` - The name of the release label used in the repository (e.g. `new release`)
+# and the following organization variables:
+# - `ORGANIZATION_NAME` - The name of the organization in the project URL (https://github.com/orgs/hackerspace-ntnu/projects/1)
+
+name: Label release pull requests
+
+on:
+  pull_request:
+    # `edited` will trigger if the PR changes its base branch
+    types: [ opened, edited ]
+
+jobs:
+  manage_release_label_of_pull_request:
+    # Do a rough check - which will weed out most PRs - before doing more detailed checks in the steps below
+    if: ${{ github.base_ref == vars.PRODUCTION_BRANCH_NAME && github.head_ref == vars.DEVELOPMENT_BRANCH_NAME
+      || contains(github.event.pull_request.labels.*.name, vars.RELEASE_LABEL_NAME) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
+        with:
+          app_id: ${{ secrets.HACKERSPACE_BOT_APP_ID }}
+          private_key: ${{ secrets.HACKERSPACE_BOT_APP_PEM }}
+
+      - name: Get label data
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          ORGANIZATION: ${{ vars.ORGANIZATION_NAME }}
+          REPOSITORY_NAME: ${{ vars.REPOSITORY_NAME }}
+          RELEASE_LABEL_NAME: ${{ vars.RELEASE_LABEL_NAME }}
+        run: |
+          gh api graphql -f query='
+            query ($org: String!, $repoName: String!) {
+              organization(login: $org) {
+                repository(name: $repoName) {
+                  labels(first: 100) {
+                    nodes {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }' -f org="$ORGANIZATION" -f repoName="$REPOSITORY_NAME" > repo_data.json
+
+          # The ID of this repository's release label
+          echo "LABEL_ID=$(jq --arg LABEL_NAME "$RELEASE_LABEL_NAME" -r '.data.organization.repository.labels.nodes[] | select(.name==$LABEL_NAME) | .id' repo_data.json)" >> "$GITHUB_ENV"
+
+      - name: Label release pull request
+        # Add the release label if the PR merges the development branch into the production branch,
+        # and it doesn't already have the release label
+        if: ${{ github.base_ref == vars.PRODUCTION_BRANCH_NAME && github.head_ref == vars.DEVELOPMENT_BRANCH_NAME
+          && !contains(github.event.pull_request.labels.*.name, vars.RELEASE_LABEL_NAME) }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          CONTENT_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation ($content: ID!, $label: ID!) {
+              addLabelsToLabelable(input: {labelableId: $content, labelIds: [$label]}) {
+                labelable {
+                  labels {
+                    totalCount
+                  }
+                }
+              }
+            }' -f content="$CONTENT_ID" -f label="$LABEL_ID" --silent
+
+      - name: Remove label from non-release pull request
+        # Remove the release label if the PR is not for merging the development branch into the production branch
+        if: ${{ (github.base_ref != vars.PRODUCTION_BRANCH_NAME || github.head_ref != vars.DEVELOPMENT_BRANCH_NAME)
+          && contains(github.event.pull_request.labels.*.name, vars.RELEASE_LABEL_NAME) }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          CONTENT_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          gh api graphql -f query='
+            mutation ($content: ID!, $label: ID!) {
+              removeLabelsFromLabelable(input: {labelableId: $content, labelIds: [$label]}) {
+                labelable {
+                  labels {
+                    totalCount
+                  }
+                }
+              }
+            }' -f content="$CONTENT_ID" -f label="$LABEL_ID" --silent

--- a/.github/workflows/project-add-issue.yml
+++ b/.github/workflows/project-add-issue.yml
@@ -1,0 +1,17 @@
+# This workflow requires that the following repository variables have been created:
+# - `ORGANIZATION_PROJECT__STATUS_VALUE_FOR_ADDED_ISSUES` - The value of the 'Status' field to set for issues when added to the project.
+# in addition to the ones required by `_reusable_add-content-to-project.yml`.
+
+name: Add issues to project
+
+on:
+  issues:
+    types: [ opened, reopened ]
+
+jobs:
+  add_to_project:
+    uses: ./.github/workflows/_reusable_add-content-to-project.yml
+    with:
+      content_id: ${{ github.event.issue.node_id }}
+      status_field_value_name: ${{ vars.ORGANIZATION_PROJECT__STATUS_VALUE_FOR_ADDED_ISSUES }}
+    secrets: inherit

--- a/.github/workflows/project-add-pull-request.yml
+++ b/.github/workflows/project-add-pull-request.yml
@@ -1,0 +1,19 @@
+# This workflow requires that the following repository variables have been created:
+# - `ORGANIZATION_PROJECT__STATUS_VALUE_FOR_ADDED_PULL_REQUESTS` - The value of the 'Status' field to set for pull requests when added to the project.
+# in addition to the ones required by `_reusable_add-content-to-project.yml`.
+
+name: Add pull requests to project
+
+on:
+  pull_request:
+    types: [ opened, reopened, ready_for_review ]
+
+jobs:
+  add_to_project:
+    # Don't run the job if it's a draft PR
+    if: ${{ !github.event.pull_request.draft }}
+    uses: ./.github/workflows/_reusable_add-content-to-project.yml
+    with:
+      content_id: ${{ github.event.pull_request.node_id }}
+      status_field_value_name: ${{ vars.ORGANIZATION_PROJECT__STATUS_VALUE_FOR_ADDED_PULL_REQUESTS }}
+    secrets: inherit


### PR DESCRIPTION
**See the commit message of e905b41465734f1767772fa47d512c0042226f96.**

Also added a workflow for labeling release PRs (96c6000af2e7325936dcbd1b8df36a62fa3464d9), and a Dependabot config for automatically updating actions used in the workflows (9976ec5eb2857a72690c99261899b8d86cd0cf1e).