### PR TITLE
Fix volume slider scale

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -3049,10 +3049,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 2135736492}
   m_HandleRect: {fileID: 1891743135}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 10
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
@@ -3543,10 +3543,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 1157484157}
   m_HandleRect: {fileID: 1688921113}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 10
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:
@@ -8293,10 +8293,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 1354532689}
   m_HandleRect: {fileID: 127141526}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 10
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scripts/UI/OptionsMenu.cs
+++ b/Assets/Scripts/UI/OptionsMenu.cs
@@ -61,19 +61,24 @@ public class OptionsMenu : MonoBehaviour
         qualityDropdown.value = QualitySettings.GetQualityLevel() - qualityNames.Length - 1;
     }
 
+    private float LinearToLogarithmicVolume(float volume)
+    {
+        return 20 * (Mathf.Log10(10 * Mathf.Max(volume, .0001f)) - 1);
+    }
+
     public void SetMasterVolume(float volume)
     {
-        mainAudioMixer.SetFloat(audioGroupMaster, volume);
+        mainAudioMixer.SetFloat(audioGroupMaster, LinearToLogarithmicVolume(volume));
     }
 
     public void SetMusicVolume(float volume)
     {
-        mainAudioMixer.SetFloat(audioGroupMusic, volume);
+        mainAudioMixer.SetFloat(audioGroupMusic, LinearToLogarithmicVolume(volume));
     }
 
     public void SetSFXVolume(float volume)
     {
-        mainAudioMixer.SetFloat(audioGroupSFX, volume);
+        mainAudioMixer.SetFloat(audioGroupSFX, LinearToLogarithmicVolume(volume));
     }
 
     public void SetQualityLevel(int qualityPresetIndex)


### PR DESCRIPTION
Make volume sliders adjust volume logarithmically to account for how humans perceive sound volume — logarithmically, not linearly.