### PR TITLE
Fix battle theme playing in bidding scene

### DIFF
--- a/Assets/Scripts/Audio/MusicTrackManager.cs
+++ b/Assets/Scripts/Audio/MusicTrackManager.cs
@@ -113,9 +113,9 @@ public class MusicTrackManager : MonoBehaviour
     {
         MusicTrack track = GetTrack(type);
         StartCoroutine(FadeOutThenSwitchTo(track));
+        if (trackSwitchingRoutine != null) StopCoroutine(trackSwitchingRoutine);
         if (track.LoopLayers.Length > 0)
         {
-            if (trackSwitchingRoutine != null) StopCoroutine(trackSwitchingRoutine);
             trackSwitchingRoutine = StartCoroutine(WaitThenSwitchToLoop(track, fadeDuration + track.Layers.First().length));
         }
     }


### PR DESCRIPTION
Yeah, I made this kind of mistake *again*.
The coroutine should stop regardless of the kind of track we start playing, otherwise it ends up starting the looping part of the battle theme while we are in the bidding scene. Yikes.