### PR TITLE
Improved reload for solar body

### DIFF
--- a/Assets/Prefabs/GunParts/SolarBody.prefab
+++ b/Assets/Prefabs/GunParts/SolarBody.prefab
@@ -60,6 +60,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5749393101405354809}
   - {fileID: 4163973509319024038}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -80,6 +81,10 @@ MonoBehaviour:
   attachmentSite: {fileID: 5853084310418703454}
   reloadEfficiencyPercentage: 0.1
   meshRenderer: {fileID: 8953527365232695383}
+  rayCastOrigin: {fileID: 5749393101405354809}
+  obscuringLayers:
+    serializedVersion: 2
+    m_Bits: 1
   reloadEfficiencyPercentagen: 0.1
 --- !u!1 &4003006189137596285
 GameObject:
@@ -247,6 +252,37 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &4757673656308517166
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5749393101405354809}
+  m_Layer: 0
+  m_Name: rayCastOrigin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5749393101405354809
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4757673656308517166}
+  m_LocalRotation: {x: 0, y: 0, z: 0.2588191, w: 0.9659258}
+  m_LocalPosition: {x: -0.060999982, y: 0.13799998, z: 0}
+  m_LocalScale: {x: 100.00002, y: 100, z: 100}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2995021758319865218}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 30}
 --- !u!1 &5245974121580100860
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Augment/AugmentImplementations/Solar/SolarBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Solar/SolarBody.cs
@@ -61,9 +61,9 @@ public class SolarBody : GunBody
 
     void FixedUpdate()
     {
-        Vector3 relativeRotationSolarpanel = rayCastOrigin.transform.TransformDirection(Vector3.up);
-        float cosineSimularity = Vector3.Dot(relativeRotationSolarpanel, globalLightDirection.eulerAngles);
-        if ((!Physics.Raycast(rayCastOrigin.position, globalLightDirection.eulerAngles, maxObscuringCheckDistance, obscuringLayers.value)) && cosineSimularity > 0)
+        Vector3 solarPanelPlaneRotation = rayCastOrigin.transform.TransformDirection(Vector3.up);
+        float orientationOverlap = Vector3.Dot(solarPanelPlaneRotation, globalLightDirection.eulerAngles);
+        if ((!Physics.Raycast(rayCastOrigin.position, globalLightDirection.eulerAngles, maxObscuringCheckDistance, obscuringLayers.value)) && orientationOverlap > 0)
         {
             Reload(gunController.stats);
         }

--- a/Assets/Scripts/Augment/AugmentImplementations/Solar/SolarBody.cs
+++ b/Assets/Scripts/Augment/AugmentImplementations/Solar/SolarBody.cs
@@ -23,6 +23,7 @@ public class SolarBody : GunBody
 
     private const float maxObscuringCheckDistance = 15f;
     private const float coolDownSeconds = 0.5f;
+    private const float chargeUpSeconds = 1; 
     private bool isCooldown = false;
 
     private const int solarPanelMaterialIndex = 3;
@@ -47,6 +48,10 @@ public class SolarBody : GunBody
     {
         if (isCooldown)
             return;
+        if (solarPanelMaterial.GetFloat("_On") == 0)
+        {
+            LeanTween.value(gameObject, SetEmissionStrength, 0, 1, chargeUpSeconds);
+        }
         solarPanelMaterial.SetFloat("_On", 1);
         gunController.Reload(reloadEfficiencyPercentagen);
         isCooldown = true;
@@ -59,16 +64,21 @@ public class SolarBody : GunBody
         isCooldown = false;
     }
 
+    private void SetEmissionStrength(float strength)
+    {
+        solarPanelMaterial.SetFloat("_EmissionStrength", strength);
+    }
+
     void FixedUpdate()
     {
-        Vector3 solarPanelPlaneRotation = rayCastOrigin.transform.TransformDirection(Vector3.up);
-        float orientationOverlap = Vector3.Dot(solarPanelPlaneRotation, globalLightDirection.eulerAngles);
+        float orientationOverlap = Vector3.Dot(rayCastOrigin.transform.up, globalLightDirection.eulerAngles);
         if ((!Physics.Raycast(rayCastOrigin.position, globalLightDirection.eulerAngles, maxObscuringCheckDistance, obscuringLayers.value)) && orientationOverlap > 0)
         {
             Reload(gunController.stats);
         }
         else
         {
+            SetEmissionStrength(0);
             solarPanelMaterial.SetFloat("_On", 0);
         }
     }

--- a/Assets/Shaders/SolarPanel.shadergraph
+++ b/Assets/Shaders/SolarPanel.shadergraph
@@ -5,6 +5,9 @@
     "m_Properties": [
         {
             "m_Id": "6d2a8ec6a4dc46e19a89d11b311d996b"
+        },
+        {
+            "m_Id": "45a4b6c6a41c4fc78f5eefdd1c9c9f0a"
         }
     ],
     "m_Keywords": [],
@@ -122,6 +125,12 @@
         },
         {
             "m_Id": "80587180b6464ee5a8cea6ff266d6553"
+        },
+        {
+            "m_Id": "c723e2cea67f4eef86636358be1c4a5c"
+        },
+        {
+            "m_Id": "7285246f536d4d71b4a967256601bfa2"
         }
     ],
     "m_GroupDatas": [],
@@ -178,9 +187,9 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "ce22ecb6dbcd404b9c34663073bfdbc1"
+                    "m_Id": "c723e2cea67f4eef86636358be1c4a5c"
                 },
-                "m_SlotId": 0
+                "m_SlotId": 1
             }
         },
         {
@@ -312,6 +321,20 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
+                    "m_Id": "7285246f536d4d71b4a967256601bfa2"
+                },
+                "m_SlotId": 0
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "c723e2cea67f4eef86636358be1c4a5c"
+                },
+                "m_SlotId": 2
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
                     "m_Id": "7898782ee5424a3b800044d7eab358f0"
                 },
                 "m_SlotId": 2
@@ -391,6 +414,20 @@
                     "m_Id": "1b3efad65c2042068e4db5393744c8cf"
                 },
                 "m_SlotId": 1
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "c723e2cea67f4eef86636358be1c4a5c"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "ce22ecb6dbcd404b9c34663073bfdbc1"
+                },
+                "m_SlotId": 0
             }
         },
         {
@@ -1008,10 +1045,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -501.6000061035156,
-            "y": -4.799984455108643,
-            "width": 208.00003051757813,
-            "height": 325.5999755859375
+            "x": -804.0,
+            "y": 7.999995231628418,
+            "width": 208.0,
+            "height": 325.6000061035156
         }
     },
     "m_Slots": [
@@ -1223,6 +1260,30 @@
     "m_Value": {
         "x": -1.5,
         "y": 0.5,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "251d139cab824d2aa17c6c074065e8c7",
+    "m_Id": 2,
+    "m_DisplayName": "T",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "T",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
         "z": 0.0,
         "w": 0.0
     },
@@ -1727,6 +1788,34 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.Internal.Vector1ShaderProperty",
+    "m_ObjectId": "45a4b6c6a41c4fc78f5eefdd1c9c9f0a",
+    "m_Guid": {
+        "m_GuidSerialized": "b687b0b9-5f6c-4c40-89a2-eeda79758a1f"
+    },
+    "m_Name": "EmissionStrength",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "EmissionStrength",
+    "m_DefaultReferenceName": "_EmissionStrength",
+    "m_OverrideReferenceName": "",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_Precision": 0,
+    "overrideHLSLDeclaration": false,
+    "hlslDeclarationOverride": 0,
+    "m_Hidden": false,
+    "m_Value": 1.0,
+    "m_FloatType": 0,
+    "m_RangeValues": {
+        "x": 0.0,
+        "y": 1.0
+    }
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.MultiplyNode",
     "m_ObjectId": "46818a844b364ee28ec770675b8360a9",
@@ -2044,7 +2133,7 @@
 }
 
 {
-    "m_SGVersion": 1,
+    "m_SGVersion": 2,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalLitSubTarget",
     "m_ObjectId": "599b011bb9884791ac667db0d532af3e",
     "m_WorkflowMode": 1,
@@ -2208,6 +2297,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "635402d614c445abb893fa6f2587b598",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.SamplerStateMaterialSlot",
     "m_ObjectId": "6362d431bc1b45758473de61d3527b51",
     "m_Id": 3,
@@ -2350,6 +2463,30 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "6d8161730f034c85bf93e0967a03f855",
+    "m_Id": 1,
+    "m_DisplayName": "B",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "B",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 1.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.BlockNode",
     "m_ObjectId": "702ea251208d40ce805aa4c37dd43d79",
     "m_Group": {
@@ -2403,6 +2540,42 @@
         "y": 0.0,
         "z": 0.0,
         "w": 0.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.PropertyNode",
+    "m_ObjectId": "7285246f536d4d71b4a967256601bfa2",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Property",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -763.199951171875,
+            "y": -56.0000114440918,
+            "width": 167.20001220703126,
+            "height": 33.59999465942383
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "ffd25cf4e52046e59c39ee4c52796597"
+        }
+    ],
+    "synonyms": [],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    },
+    "m_Property": {
+        "m_Id": "45a4b6c6a41c4fc78f5eefdd1c9c9f0a"
     }
 }
 
@@ -2964,6 +3137,9 @@
     "m_ChildObjectList": [
         {
             "m_Id": "6d2a8ec6a4dc46e19a89d11b311d996b"
+        },
+        {
+            "m_Id": "45a4b6c6a41c4fc78f5eefdd1c9c9f0a"
         }
     ]
 }
@@ -3527,6 +3703,7 @@
     "m_SGVersion": 1,
     "m_Type": "UnityEditor.Rendering.Universal.ShaderGraph.UniversalTarget",
     "m_ObjectId": "b2d0fa3ccfb84ec091a331405e2f21c8",
+    "m_Datas": [],
     "m_ActiveSubTarget": {
         "m_Id": "599b011bb9884791ac667db0d532af3e"
     },
@@ -3539,6 +3716,7 @@
     "m_AlphaClip": false,
     "m_CastShadows": true,
     "m_ReceiveShadows": true,
+    "m_SupportsLODCrossFade": false,
     "m_CustomEditorGUI": "",
     "m_SupportVFX": false
 }
@@ -3614,7 +3792,8 @@
     },
     "m_TextureType": 0,
     "m_NormalMapSpace": 0,
-    "m_EnableGlobalMipBias": true
+    "m_EnableGlobalMipBias": true,
+    "m_MipSamplingMode": 0
 }
 
 {
@@ -3711,6 +3890,52 @@
         "m_SerializableColors": []
     },
     "m_SerializedDescriptor": "SurfaceDescription.Occlusion"
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.LerpNode",
+    "m_ObjectId": "c723e2cea67f4eef86636358be1c4a5c",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Lerp",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": -367.20001220703127,
+            "y": -134.40000915527345,
+            "width": 208.00003051757813,
+            "height": 325.6000061035156
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "e3cd2154797f4d91b39d25c97be44412"
+        },
+        {
+            "m_Id": "6d8161730f034c85bf93e0967a03f855"
+        },
+        {
+            "m_Id": "251d139cab824d2aa17c6c074065e8c7"
+        },
+        {
+            "m_Id": "635402d614c445abb893fa6f2587b598"
+        }
+    ],
+    "synonyms": [
+        "mix",
+        "blend",
+        "linear interpolate"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
+    }
 }
 
 {
@@ -4105,6 +4330,30 @@
     "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "e3cd2154797f4d91b39d25c97be44412",
+    "m_Id": 0,
+    "m_DisplayName": "A",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "A",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
     }
 }
 
@@ -4520,5 +4769,20 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.Vector1MaterialSlot",
+    "m_ObjectId": "ffd25cf4e52046e59c39ee4c52796597",
+    "m_Id": 0,
+    "m_DisplayName": "EmissionStrength",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": 0.0,
+    "m_DefaultValue": 0.0,
+    "m_Labels": []
 }
 


### PR DESCRIPTION
The solar body now actually considers where the sun is, and if there are any obscuring objects to block the sun, making for more intuitive reload mechanics

![solarBetterReload](https://github.com/hackerspace-ntnu/Prosjekt-Spill-H22/assets/54811121/242cc714-a1bd-4c5a-b8ae-e1d340c0f689)
