### PR TITLE
Fix exception on solo suicide

### DIFF
--- a/Assets/Scripts/Gamestate/Round.cs
+++ b/Assets/Scripts/Gamestate/Round.cs
@@ -111,7 +111,7 @@ public class Round
         // If it was a suicide, we should give the surviving player the win if there's only one
         else if (livingPlayers.Count < 2)
         {
-            CheckWinCondition(livingPlayers.First());
+            CheckWinCondition(livingPlayers.FirstOrDefault());
         }
     }
 


### PR DESCRIPTION
Replace First with FirstOrDefault to avoid exception when there's no one else alive.

Closes #261 