### PR TITLE
Move death box up in Grand Canyon

### DIFF
--- a/Assets/Scenes/GrandCanyon.unity
+++ b/Assets/Scenes/GrandCanyon.unity
@@ -4746,7 +4746,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 841330374042089744, guid: 79027cbae5a74954bbf1972c83fc9e5e, type: 3}
       propertyPath: m_LocalScale.y
-      value: 50
+      value: 74.2
       objectReference: {fileID: 0}
     - target: {fileID: 841330374042089744, guid: 79027cbae5a74954bbf1972c83fc9e5e, type: 3}
       propertyPath: m_LocalScale.z


### PR DESCRIPTION
This lessens the time spent falling before players actually die there.

⚠️ This might mess with players trying to fly underneath the map using the knockback extension